### PR TITLE
188 working masternode status and count rpc commands

### DIFF
--- a/addrmgr/knownaddress_test.go
+++ b/addrmgr/knownaddress_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/dashevo/dashd-go/addrmgr"
 )
 
 func TestChance(t *testing.T) {

--- a/btcjson/dashevocmds.go
+++ b/btcjson/dashevocmds.go
@@ -50,14 +50,14 @@ func NewQuorumSignCmd(quorumType LLMQType, requestId string, messageHash string,
 	}
 }
 
-// QuorumCmd defines the quorum JSON-RPC command.
+// QuorumInfoCmd defines the quorum info JSON-RPC command.
 type QuorumInfoCmd struct {
 	LLMQType       LLMQType
 	QuorumHash     string
 	IncludeSkShare bool
 }
 
-// NewQuorumCmd returns a new instance which can be used to issue a quorum
+// NewQuorumInfoCmd returns a new instance which can be used to issue a quorum
 // JSON-RPC command.
 func NewQuorumInfoCmd(quorumType LLMQType, quorumHash string, includeSkShare bool) *QuorumInfoCmd {
 	return &QuorumInfoCmd{

--- a/btcjson/dashmasternodecmds.go
+++ b/btcjson/dashmasternodecmds.go
@@ -8,28 +8,31 @@
 
 package btcjson
 
-// MasternodeCmdSubCmd defines the sub command used in the quorum JSON-RPC command.
-type MasternodeCmdSubCmd string
+// MasternodeSubCmd defines the sub command used in the quorum JSON-RPC command.
+type MasternodeSubCmd string
 
+// Masternode subcommands
 const (
-	// MasternodeStatus indicates the specified host should be added as a persistent
-	// peer.
-	MasternodeStatus MasternodeCmdSubCmd = "status"
+	MasternodeStatus MasternodeSubCmd = "status"
+	MasternodeCount  MasternodeSubCmd = "count"
 )
 
-// MasternodeStatusCmd defines the quorum JSON-RPC command.
-type MasternodeStatusCmd struct {
+// MasternodeCmd defines the quorum JSON-RPC command.
+type MasternodeCmd struct {
+	SubCmd MasternodeSubCmd `jsonrpcusage:"\"status|count\""`
 }
 
-// NewMasternodeStatusCmd returns a new instance which can be used to issue a quorum
+// NewMasternodeCmd returns a new instance which can be used to issue a quorum
 // JSON-RPC command.
-func NewMasternodeStatusCmd() *MasternodeStatusCmd {
-	return &MasternodeStatusCmd{}
+func NewMasternodeCmd(sub MasternodeSubCmd) *MasternodeCmd {
+	return &MasternodeCmd{
+		SubCmd: sub,
+	}
 }
 
 func init() {
 	// No special flags for commands in this file.
 	flags := UsageFlag(0)
 
-	MustRegisterCmd("masternode status", (*MasternodeStatusCmd)(nil), flags)
+	MustRegisterCmd("masternode", (*MasternodeCmd)(nil), flags)
 }

--- a/btcjson/dashmasternodecmds_test.go
+++ b/btcjson/dashmasternodecmds_test.go
@@ -1,1 +1,105 @@
 package btcjson_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/dashevo/dashd-go/btcjson"
+)
+
+// TestDashMasternodeCmds tests all of the btcd extended commands marshal and unmarshal
+// into valid results include handling of optional fields being omitted in the
+// marshalled command, while optional fields with defaults have the default
+// assigned on unmarshalled commands.
+func TestDashMasternodeCmds(t *testing.T) {
+	t.Parallel()
+
+	testID := int(1)
+	tests := []struct {
+		name         string
+		newCmd       func() (interface{}, error)
+		staticCmd    func() interface{}
+		marshalled   string
+		unmarshalled interface{}
+	}{
+		{
+			name: "masternode status",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("masternode", "status")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewMasternodeCmd(btcjson.MasternodeStatus)
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"masternode","params":["status"],"id":1}`,
+			unmarshalled: &btcjson.MasternodeCmd{SubCmd: btcjson.MasternodeStatus},
+		},
+		{
+			name: "masternode count",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("masternode", "count")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewMasternodeCmd(btcjson.MasternodeCount)
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"masternode","params":["count"],"id":1}`,
+			unmarshalled: &btcjson.MasternodeCmd{SubCmd: btcjson.MasternodeCount},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Marshal the command as created by the new static command
+			// creation function.
+			marshalled, err := btcjson.MarshalCmd(testID, test.staticCmd())
+			if err != nil {
+				t.Fatalf("MarshalCmd unexpected error: %v", err)
+			}
+
+			if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+				t.Fatalf("Test unexpected marshalled data - "+
+					"got %s, want %s", marshalled, test.marshalled)
+			}
+
+			// Ensure the command is created without error via the generic
+			// new command creation function.
+			cmd, err := test.newCmd()
+			if err != nil {
+				t.Fatalf("Test unexpected NewCmd error: %v ", err)
+			}
+
+			// Marshal the command as created by the generic new command
+			// creation function.
+			marshalled, err = btcjson.MarshalCmd(testID, cmd)
+			if err != nil {
+				t.Fatalf("MarshalCmd unexpected error: %v", err)
+			}
+
+			if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+				t.Fatalf("Unexpected marshalled data - "+
+					"got %s, want %s", marshalled, test.marshalled)
+			}
+
+			var request btcjson.Request
+			if err := json.Unmarshal(marshalled, &request); err != nil {
+				t.Fatalf("Unexpected error while "+
+					"unmarshalling JSON-RPC request: %v", err)
+			}
+
+			cmd, err = btcjson.UnmarshalCmd(&request)
+			if err != nil {
+				t.Fatalf("UnmarshalCmd unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(cmd, test.unmarshalled) {
+				t.Fatalf("Unexpected unmarshalled command "+
+					"- got %s, want %s",
+					fmt.Sprintf("(%T) %+[1]v", cmd),
+					fmt.Sprintf("(%T) %+[1]v\n", test.unmarshalled))
+			}
+		})
+	}
+}

--- a/btcjson/dashmasternoderesults.go
+++ b/btcjson/dashmasternoderesults.go
@@ -13,6 +13,14 @@ type MasternodeStatusResult struct {
 	Status          string   `json:"status"`
 }
 
+// MasternodeCountResult models the data from the masternode count command.
+// https://dashcore.readme.io/docs/core-api-ref-remote-procedure-calls-dash#masternode-count
+type MasternodeCountResult struct {
+	Total   int `json:"total"`
+	Enabled int `json:"enabled"`
+}
+
+// DMNState is used in masternode status
 type DMNState struct {
 	Service           string `json:"service"`
 	RegisteredHeight  int    `json:"registeredHeight"`

--- a/btcjson/walletsvrresults_test.go
+++ b/btcjson/walletsvrresults_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/btcsuite/btcd/txscript"
+	"github.com/dashevo/dashd-go/txscript"
 	"github.com/davecgh/go-spew/spew"
 )
 

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -853,7 +853,7 @@ func (c *Client) EstimateFee(numBlocks int64) (float64, error) {
 	return c.EstimateFeeAsync(numBlocks).Receive()
 }
 
-// FutureEstimateFeeResult is a future promise to deliver the result of a
+// FutureEstimateSmartFeeResult is a future promise to deliver the result of a
 // EstimateSmartFeeAsync RPC invocation (or an applicable error).
 type FutureEstimateSmartFeeResult chan *response
 

--- a/rpcclient/evo.go
+++ b/rpcclient/evo.go
@@ -8,6 +8,7 @@ package rpcclient
 
 import (
 	"encoding/json"
+
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/dashevo/dashd-go/btcjson"
 )

--- a/rpcclient/example_test.go
+++ b/rpcclient/example_test.go
@@ -6,13 +6,14 @@ package rpcclient
 
 import (
 	"fmt"
+
 	"github.com/dashevo/dashd-go/btcjson"
 )
 
 var connCfg = &ConnConfig{
-	Host:         "localhost:8332",
-	User:         "user",
-	Pass:         "pass",
+	Host:         "localhost:19998",
+	User:         "dashrpc",
+	Pass:         "rpcpassword",
 	HTTPPostMode: true,
 	DisableTLS:   true,
 }

--- a/rpcclient/masternode.go
+++ b/rpcclient/masternode.go
@@ -8,6 +8,7 @@ package rpcclient
 
 import (
 	"encoding/json"
+
 	"github.com/dashevo/dashd-go/btcjson"
 )
 
@@ -25,7 +26,6 @@ func (r FutureGetMasternodeStatusResult) Receive() (*btcjson.MasternodeStatusRes
 		return nil, err
 	}
 
-	// Unmarshal as a Quorum Info Result
 	var masternodeStatusResult btcjson.MasternodeStatusResult
 	err = json.Unmarshal(res, &masternodeStatusResult)
 	if err != nil {
@@ -35,13 +35,12 @@ func (r FutureGetMasternodeStatusResult) Receive() (*btcjson.MasternodeStatusRes
 	return &masternodeStatusResult, nil
 }
 
-// QuorumSignAsync returns an instance of a type that can be used to get
+// MasternodeStatusAsync returns an instance of a type that can be used to get
 // the result of the RPC at some future time by invoking the Receive function on
 // the returned instance.
 //
 func (c *Client) MasternodeStatusAsync() FutureGetMasternodeStatusResult {
-
-	cmd := btcjson.NewMasternodeStatusCmd()
+	cmd := btcjson.NewMasternodeCmd(btcjson.MasternodeStatus)
 
 	return FutureGetMasternodeStatusResult{
 		client:   c,
@@ -52,4 +51,46 @@ func (c *Client) MasternodeStatusAsync() FutureGetMasternodeStatusResult {
 // MasternodeStatus returns the masternode status.
 func (c *Client) MasternodeStatus() (*btcjson.MasternodeStatusResult, error) {
 	return c.MasternodeStatusAsync().Receive()
+}
+
+// ----------------- masternode count ---------------------
+
+// FutureGetMasternodeCountResult is a future promise to deliver the result of a
+// MasternodeStatusAsync RPC invocation (or an applicable error).
+type FutureGetMasternodeCountResult struct {
+	client   *Client
+	Response chan *response
+}
+
+// Receive waits for the response promised by the future and returns the member signature for the quorum.
+func (r FutureGetMasternodeCountResult) Receive() (*btcjson.MasternodeCountResult, error) {
+	res, err := receiveFuture(r.Response)
+	if err != nil {
+		return nil, err
+	}
+
+	var result btcjson.MasternodeCountResult
+	err = json.Unmarshal(res, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// MasternodeCountAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+func (c *Client) MasternodeCountAsync() FutureGetMasternodeCountResult {
+	cmd := btcjson.NewMasternodeCmd(btcjson.MasternodeCount)
+
+	return FutureGetMasternodeCountResult{
+		client:   c,
+		Response: c.sendCmd(cmd),
+	}
+}
+
+// MasternodeCount returns the masternode count.
+func (c *Client) MasternodeCount() (*btcjson.MasternodeCountResult, error) {
+	return c.MasternodeCountAsync().Receive()
 }

--- a/rpcclient/masternode_test.go
+++ b/rpcclient/masternode_test.go
@@ -1,0 +1,100 @@
+package rpcclient
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"github.com/dashevo/dashd-go/btcjson"
+)
+
+func TestGetBlockCount(t *testing.T) {
+	client, err := New(connCfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	blockCount, err := client.GetBlockCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get("https://testnet-insight.dashevo.org/insight-api/status")
+	if err != nil {
+		t.Fatal("colud not get insite", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal("colud not read body", err)
+	}
+
+	r := struct {
+		Info struct {
+			Blocks int64 `json:"blocks"`
+		} `json:"info"`
+	}{}
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatal("could not unmarshal body", err)
+	}
+	if bl := r.Info.Blocks; bl != blockCount {
+		t.Error("node not synced with blockchain, block count did not match insight", blockCount, bl)
+	}
+	t.Log("Block count:", blockCount)
+}
+
+func TestMasternodeStatus(t *testing.T) {
+	client, err := New(connCfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	result, err := client.MasternodeStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli := &btcjson.MasternodeStatusResult{}
+	compareWithCliCommand(t, result, cli, "masternode", "status")
+}
+
+func TestMasternodeCount(t *testing.T) {
+	client, err := New(connCfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Shutdown()
+
+	result, err := client.MasternodeCount()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cli := &btcjson.MasternodeCountResult{}
+	compareWithCliCommand(t, result, cli, "masternode", "count")
+}
+
+func compareWithCliCommand(t *testing.T, rpc, cli interface{}, cmds ...string) {
+	cmd := append([]string{"-testnet"}, cmds...)
+	out, err := exec.Command("dash-cli", cmd...).Output()
+	if err != nil {
+		t.Fatal("Could not run dash-cli command", err)
+	}
+
+	if err := json.Unmarshal(out, &cli); err != nil {
+		t.Log(string(out))
+		t.Fatal("Could not marshal dash-cli output", err)
+	}
+
+	if !reflect.DeepEqual(rpc, cli) {
+		t.Error("rpc result did not match cli")
+		t.Logf("rpc result: %#v", rpc)
+		t.Logf("cli result: %#v", cli)
+		t.Logf("cli string: %s", string(out))
+	}
+}

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -2569,7 +2569,7 @@ func (c *Client) GetInfo() (*btcjson.InfoWalletResult, error) {
 	return c.GetInfoAsync().Receive()
 }
 
-// FutureImportPubKeyResult is a future promise to deliver the result of an
+// FutureWalletCreateFundedPsbtResult is a future promise to deliver the result of an
 // WalletCreateFundedPsbt RPC invocation (or an applicable error).
 type FutureWalletCreateFundedPsbtResult chan *response
 


### PR DESCRIPTION
Includes tests that call `dash-cli` and compares the output