### PR TITLE
feat: add QuorumVerify method

### DIFF
--- a/btcjson/dashevocmds.go
+++ b/btcjson/dashevocmds.go
@@ -79,12 +79,9 @@ type QuorumCmdSubCmd string
 
 // Quorum commands https://dashcore.readme.io/docs/core-api-ref-remote-procedure-calls-evo#quorum
 const (
-	// QuorumSign indicates the specified host should be added as a persistent
-	// peer.
-	QuorumSign QuorumCmdSubCmd = "sign"
-
-	// QuorumInfo indicates the specified peer should be removed.
-	QuorumInfo QuorumCmdSubCmd = "info"
+	QuorumSign   QuorumCmdSubCmd = "sign"
+	QuorumVerify QuorumCmdSubCmd = "verify"
+	QuorumInfo   QuorumCmdSubCmd = "info"
 
 	// QuorumList lists all quorums
 	QuorumList QuorumCmdSubCmd = "list"
@@ -128,6 +125,7 @@ type QuorumCmd struct {
 	RequestID   *string   `json:",omitempty"`
 	MessageHash *string   `json:",omitempty"`
 	QuorumHash  *string   `json:",omitempty"`
+	Signature   *string   `json:",omitempty"`
 
 	Submit               *bool        `json:",omitempty"`
 	IncludeSkShare       *bool        `json:",omitempty"`
@@ -151,7 +149,20 @@ func NewQuorumSignCmd(quorumType LLMQType, requestID, messageHash, quorumHash st
 	cmd.QuorumHash = &quorumHash
 	cmd.Submit = &submit
 	return cmd
+}
 
+// NewQuorumVerifyCmd returns a new instance which can be used to issue a quorum
+// JSON-RPC command.
+func NewQuorumVerifyCmd(quorumType LLMQType, requestID string, messageHash string, signature string, quorumHash string) *QuorumCmd {
+	cmd := &QuorumCmd{
+		SubCmd:      QuorumVerify,
+		LLMQType:    &quorumType,
+		RequestID:   &requestID,
+		MessageHash: &messageHash,
+		Signature:   &signature,
+		QuorumHash:  &quorumHash,
+	}
+	return cmd
 }
 
 // NewQuorumInfoCmd returns a new instance which can be used to issue a quorum

--- a/btcjson/dashevocmds_test.go
+++ b/btcjson/dashevocmds_test.go
@@ -78,6 +78,32 @@ func TestDashEvoCmds(t *testing.T) {
 				IncludeSkShare: pBool(false),
 			},
 		},
+		{
+			name: "quorum verify",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("quorum verify",
+					btcjson.LLMQType_100_67,
+					"0067c4fd779a195a95b267e263c631f71f83f8d5e6191091289d114012b373a1",
+					"ce490ca26cad6f1749ff9b977fe0fe4ece4391166f69be75c4619bc94b184dbc",
+					"6f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241236",
+					false)
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewQuorumVerifyCmd(btcjson.LLMQType_100_67,
+					"0067c4fd779a195a95b267e263c631f71f83f8d5e6191091289d114012b373a1",
+					"ce490ca26cad6f1749ff9b977fe0fe4ece4391166f69be75c4619bc94b184dbc",
+					"5f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241235",
+					"6f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241236")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"quorum sign","params":[4,"0067c4fd779a195a95b267e263c631f71f83f8d5e6191091289d114012b373a1","ce490ca26cad6f1749ff9b977fe0fe4ece4391166f69be75c4619bc94b184dbc","5f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241235","6f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241236",],"id":1}`,
+			unmarshalled: &btcjson.QuorumCmd{
+				LLMQType:    pLLMQType(btcjson.LLMQType_100_67),
+				RequestID:   pString("0067c4fd779a195a95b267e263c631f71f83f8d5e6191091289d114012b373a1"),
+				MessageHash: pString("ce490ca26cad6f1749ff9b977fe0fe4ece4391166f69be75c4619bc94b184dbc"),
+				Signature:   pString("5f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241235"),
+				QuorumHash:  pString("6f1018f54507606069303fd16257434073c6f374729b0090bb9dbbe629241236"),
+			},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/btcjson/dashevocmds_test.go
+++ b/btcjson/dashevocmds_test.go
@@ -117,7 +117,7 @@ func TestDashEvoCmds(t *testing.T) {
 			continue
 		}
 
-		if !bytes.Equalo(marshalled, []byte(test.marshalled)) {
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
 			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
 				"got %s, want %s", i, test.name, marshalled,
 				test.marshalled)

--- a/btcjson/dashevocmds_test.go
+++ b/btcjson/dashevocmds_test.go
@@ -117,7 +117,7 @@ func TestDashEvoCmds(t *testing.T) {
 			continue
 		}
 
-		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+		if !bytes.Equalo(marshalled, []byte(test.marshalled)) {
 			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
 				"got %s, want %s", i, test.name, marshalled,
 				test.marshalled)

--- a/btcjson/dashevoresults.go
+++ b/btcjson/dashevoresults.go
@@ -23,6 +23,13 @@ type QuorumSignResultWithBool struct {
 	Result bool `json:"result,omitempty"`
 }
 
+// QuorumVerifyResult models the data from the quorum verify command.
+// returns a boolean.
+type QuorumVerifyResult struct {
+	// Result is the output if submit was true
+	Result bool `json:"result,omitempty"`
+}
+
 // UnmarshalJSON is a custom unmarshal because the result can be just a boolean
 func (qsr *QuorumSignResultWithBool) UnmarshalJSON(data []byte) error {
 	if bl, err := strconv.ParseBool(string(data)); err == nil {


### PR DESCRIPTION
This PR implement `quorum verify` RPC call to verify various quorum signatures through dashcore's RPC